### PR TITLE
Fix buffer overflow and memory leaks in `convert_tag_to_code`

### DIFF
--- a/ratify/rtf-serialize.c
+++ b/ratify/rtf-serialize.c
@@ -110,9 +110,11 @@ convert_tag_to_code(GtkTextTag *tag, WriterContext *ctx)
     if (name) {
         if (strcmp(name, "rtf-superscript") == 0) {
             g_hash_table_insert(ctx->tag_codes, tag, g_strdup("\\super"));
+            g_free(name);
             return;
         } else if (strcmp(name, "rtf-subscript") == 0) {
             g_hash_table_insert(ctx->tag_codes, tag, g_strdup("\\sub"));
+            g_free(name);
             return;
         }
         g_free(name);

--- a/ratify/rtf-serialize.c
+++ b/ratify/rtf-serialize.c
@@ -97,7 +97,7 @@ RTF code. */
 static void
 convert_tag_to_code(GtkTextTag *tag, WriterContext *ctx)
 {
-    bool val;
+    gboolean val;
     int pixels, pango, colornum;
     double factor, points;
     GdkColor *color;


### PR DESCRIPTION
`gboolean` can be larger than the standard `bool` type, so when `g_object_get` tries to write a `gboolean` to a `bool *`, you can get a buffer overflow. This buffer overflow occurred on my Arch Linux system while I was using `inform7-ide` and triggered stack smashing protection, which is how I found it; and I confirmed that the patch fixes the crash for me. There may be other such bugs in the code. I don't really understand glib enough to check the types of all these variables myself... For instance, I don't understand why `color` is a pointer and `just` isn't.

More minor, I noticed while looking at `convert_tag_to_code` that the two early returns skipped a `g_free`.